### PR TITLE
Add reusable tooltip module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,41 @@
-- 👋 Hi, I’m @arirattan
-- 👀 I’m interested in cloud and networking services, computer games and mountain bikes 
-- 🌱 I’m currently learning Microsoft azure admin and Microsoft 365 admin
-- 💞️ I’m looking to collaborate on dont feel im ready to start working with others yet as im still learning the ropes
-- 📫 How to reach me ...
+# JSON Configuration Visualizer
 
-<!---
-arirattan/arirattan is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+This repository contains a simple Tkinter application for exploring Open Components System (OCS) JSON configuration files.
+
+Features include:
+
+- Load one or more JSON files for inspection
+- View each configuration section in its own tab with optional tooltips
+- Tooltip text is stored in `tooltip.py` for easy customization
+- Search across all fields for quick navigation
+- Diff view between the first two files when `jsondiff` is installed
+- Heatmap comparison across all loaded files
+- Light and dark mode with automatic theme detection
+- Tabs load lazily for improved performance
+
+## Requirements
+
+- Python 3
+- Tkinter (usually bundled with Python)
+- [`jsondiff`](https://pypi.org/project/jsondiff/) (optional; provides diff view)
+- [`darkdetect`](https://pypi.org/project/darkdetect/) (optional; detects OS theme)
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the visualizer with:
+
+```bash
+python json_visualizer.py
+```
+
+Use the **Upload JSON File(s)** button to load any number of configuration files. When multiple files are provided, a heatmap window summarizes their differences and a detailed diff between the first two files is also available.
+
+## License
+
+This project is released under the MIT License.

--- a/json_visualizer.py
+++ b/json_visualizer.py
@@ -1,0 +1,486 @@
+"""JSON Configuration Visualizer for OCS settings.
+
+This script provides a GUI to inspect one or two JSON files side by side. It
+shows each configuration section in a tab with optional descriptions and offers
+a search bar for quick navigation. When two files are loaded, a diff view is
+created to highlight their differences.
+"""
+
+import json
+import os
+import tkinter as tk
+import tkinter.font as tkfont
+from tkinter import filedialog, messagebox, ttk
+from tooltip import SECTION_TOOLTIPS, Tooltip
+
+try:
+    import darkdetect
+except Exception:  # pragma: no cover - optional dependency
+    darkdetect = None
+
+try:
+    from jsondiff import diff
+except Exception:
+    diff = None  # Diff functionality disabled if jsondiff is not installed
+
+
+
+
+class JSONVisualizerApp:
+    """Tkinter application to visualize JSON configuration files."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title("JSON Configuration Visualizer (OCS)")
+        self.root.geometry("1000x700")
+
+        # Increase default font size for readability
+        default_font = tkfont.nametofont("TkDefaultFont")
+        text_font = tkfont.nametofont("TkTextFont")
+        default_font.configure(size=12)
+        text_font.configure(size=12)
+
+        # List of dicts: {'name': filename, 'data': json_data}
+        self.files: list[dict] = []
+        self.current_tabs: dict[str, tuple[tk.Canvas, ttk.Frame]] = {}
+        self.search_results: list[tuple[str, str]] = []
+        self.all_entries: list[ttk.Entry] = []
+
+        # Lazy-load bookkeeping
+        self.tab_json: dict[str, dict] = {}
+        self.tab_frames: dict[str, ttk.Frame] = {}
+        self.tab_initialized: set[str] = set()
+
+        style = ttk.Style(self.root)
+        try:
+            if "vista" in style.theme_names():
+                style.theme_use("vista")
+            elif "xpnative" in style.theme_names():
+                style.theme_use("xpnative")
+            else:
+                style.theme_use(style.theme_use())
+        except Exception:
+            pass
+
+        self.dark_mode = False
+        if darkdetect is not None:
+            try:
+                self.dark_mode = darkdetect.theme().lower() == "dark"
+            except Exception:
+                pass
+
+        self.theme_button = ttk.Button(root, text="Toggle Dark Mode", command=self.toggle_theme)
+        self.theme_button.pack(pady=5)
+        self.apply_theme()
+
+        self.upload_button = ttk.Button(root, text="Upload JSON File(s)", command=self.load_files)
+        self.upload_button.pack(pady=10)
+
+        self.search_frame = ttk.Frame(root)
+        self.search_frame.pack(fill="x", padx=10)
+        ttk.Label(self.search_frame, text="Search:").pack(side="left", padx=(0, 5))
+        self.search_var = tk.StringVar()
+        self.search_entry = ttk.Entry(self.search_frame, textvariable=self.search_var)
+        self.search_entry.pack(side="left", fill="x", expand=True)
+        self.search_entry.bind("<Return>", lambda e: self.perform_search())
+        self.search_button = ttk.Button(self.search_frame, text="Go", command=self.perform_search)
+        self.search_button.pack(side="left", padx=(5, 0))
+
+        self.results_listbox = tk.Listbox(root, height=5)
+        self.results_listbox.pack(fill="x", padx=10)
+        self.results_listbox.bind("<<ListboxSelect>>", self.on_result_select)
+
+        self.notebook = ttk.Notebook(root)
+        self.notebook.pack(fill="both", expand=True, padx=10, pady=10)
+        self.notebook.bind("<<NotebookTabChanged>>", self.on_tab_changed)
+
+        self.info_label = ttk.Label(root, text="Please upload one or more JSON files to begin.")
+        self.info_label.pack(pady=5)
+
+    # ---------------------------
+    # Theming
+    # ---------------------------
+    def apply_theme(self) -> None:
+        """Apply light or dark color scheme."""
+        if self.dark_mode:
+            colors = {
+                "background": "#2e2e2e",
+                "foreground": "#ffffff",
+                "activeBackground": "#444444",
+                "activeForeground": "#ffffff",
+            }
+        else:
+            colors = {
+                "background": "#f0f0f0",
+                "foreground": "#000000",
+                "activeBackground": "#d9d9d9",
+                "activeForeground": "#000000",
+            }
+        self.root.tk_setPalette(**colors)
+
+    def toggle_theme(self) -> None:
+        self.dark_mode = not self.dark_mode
+        self.apply_theme()
+
+    # ---------------------------
+    # File Handling
+    # ---------------------------
+    def load_files(self) -> None:
+        """Open a file dialog and load selected JSON files."""
+        file_paths = filedialog.askopenfilenames(filetypes=[("JSON files", "*.json")])
+        if not file_paths:
+            return
+
+        self.files.clear()
+        self.current_tabs.clear()
+        self.all_entries.clear()
+        for tab in self.notebook.tabs():
+            self.notebook.forget(tab)
+        self.results_listbox.delete(0, tk.END)
+        self.search_var.set("")
+        self.search_results.clear()
+
+        for path in file_paths:
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                filename = os.path.basename(path)
+                self.files.append({"name": filename, "data": data})
+            except Exception as exc:  # pragma: no cover - GUI feedback
+                messagebox.showerror("Error", f"Failed to load {path}: {exc}")
+                return
+
+        self.update_view()
+
+    def update_view(self) -> None:
+        """Clear existing tabs and display loaded files."""
+        for tab in self.notebook.tabs():
+            self.notebook.forget(tab)
+        self.current_tabs.clear()
+        self.results_listbox.delete(0, tk.END)
+        self.search_var.set("")
+        self.search_results.clear()
+        self.all_entries.clear()
+
+        self.info_label.config(text="")
+
+        if len(self.files) == 1:
+            self.display_tabs(self.files[0]["data"], self.files[0]["name"])
+        elif len(self.files) >= 2:
+            self.display_tabs(self.files[0]["data"], self.files[0]["name"])
+            self.display_comparison(
+                base_data=self.files[0]["data"],
+                base_name=self.files[0]["name"],
+                compare_data=self.files[1]["data"],
+                compare_name=self.files[1]["name"],
+            )
+            self.display_heatmap()
+
+    # ---------------------------
+    # Display Helpers
+    # ---------------------------
+    def display_tabs(self, data: dict, filename: str) -> None:
+        self.tab_json.clear()
+        self.tab_frames.clear()
+        self.tab_initialized.clear()
+
+        for key, value in data.items():
+            frame = ttk.Frame(self.notebook)
+            self.notebook.add(frame, text=key)
+            ttk.Label(frame, text="Select tab to load...").pack()
+            self.tab_json[key] = value
+            self.tab_frames[key] = frame
+
+        def _init_first() -> None:
+            event = tk.Event()
+            event.widget = self.notebook
+            self.on_tab_changed(event)
+
+        self.root.after_idle(_init_first)
+
+    def build_nested_frame(
+        self,
+        parent: ttk.Frame,
+        data,
+        canvas: tk.Canvas | None = None,
+        indent: int = 0,
+        key_name: str | None = None,
+        path_prefix: str = "",
+    ) -> None:
+        """Recursively render nested data structures."""
+        if isinstance(data, dict):
+            obj_label = key_name if key_name else "Object"
+            frame = ttk.LabelFrame(parent, text=obj_label, padding=10)
+            frame.pack(fill="x", padx=indent * 20 + 10, pady=5, anchor="nw")
+
+            if path_prefix in SECTION_TOOLTIPS:
+                Tooltip(frame, SECTION_TOOLTIPS[path_prefix])
+
+            for k, v in data.items():
+                new_path = f"{path_prefix}.{k}" if path_prefix else k
+                self.build_nested_frame(
+                    frame, v, canvas=canvas, indent=indent + 1, key_name=k, path_prefix=new_path
+                )
+        elif isinstance(data, list):
+            list_label = f"{key_name} [List]" if key_name else "List"
+            frame = ttk.LabelFrame(parent, text=list_label, padding=10)
+            frame.pack(fill="x", padx=indent * 20 + 10, pady=5, anchor="nw")
+
+            if path_prefix in SECTION_TOOLTIPS:
+                Tooltip(frame, SECTION_TOOLTIPS[path_prefix])
+
+            for idx, item in enumerate(data):
+                new_path = f"{path_prefix}[{idx}]"
+                self.build_nested_frame(
+                    frame,
+                    item,
+                    canvas=canvas,
+                    indent=indent + 1,
+                    key_name=f"[{idx}]",
+                    path_prefix=new_path,
+                )
+        else:
+            row = ttk.Frame(parent)
+            row.pack(fill="x", padx=indent * 20 + 10, pady=2, anchor="nw")
+            display_key = key_name if key_name else str(data)
+            label = ttk.Label(row, text=f"{display_key}:", width=30)
+            label.pack(side="left")
+
+            if path_prefix in SECTION_TOOLTIPS:
+                Tooltip(label, SECTION_TOOLTIPS[path_prefix])
+
+            entry = ttk.Entry(row)
+            entry.insert(0, str(data))
+            entry.pack(side="left", fill="x", expand=True)
+
+            entry.full_path = path_prefix
+            entry.parent_canvas = canvas
+            entry.default_bg = entry.cget("background")
+            self.all_entries.append(entry)
+
+    # ---------------------------
+    # Search
+    # ---------------------------
+    def perform_search(self) -> None:
+        query = self.search_var.get().strip().lower()
+        self.results_listbox.delete(0, tk.END)
+        self.search_results.clear()
+
+        for ent in self.all_entries:
+            ent.config(background=ent.default_bg)
+
+        if not query:
+            return
+
+        for tab_key, (canvas, scrollable) in self.current_tabs.items():
+            for widget in scrollable.winfo_children():
+                self.search_in_widget(widget, query, tab_key)
+
+        for i, (tab_key, path) in enumerate(self.search_results):
+            self.results_listbox.insert(i, f"{tab_key}: {path}")
+
+    def search_in_widget(self, widget: tk.Widget, query: str, tab_key: str) -> None:
+        if isinstance(widget, ttk.Entry):
+            value = widget.get().lower()
+            path = getattr(widget, "full_path", "")
+            if query in value or query in path.lower():
+                widget.config(background="yellow")
+                self.search_results.append((tab_key, path))
+        elif isinstance(widget, (ttk.Frame, ttk.LabelFrame)):
+            for child in widget.winfo_children():
+                self.search_in_widget(child, query, tab_key)
+
+    def on_tab_changed(self, event: tk.Event) -> None:
+        """Lazy-load tab content when selected."""
+        tab_id = event.widget.select()
+        key = event.widget.tab(tab_id, "text")
+        if key in self.tab_initialized:
+            return
+        frame = self.tab_frames.get(key)
+        data = self.tab_json.get(key)
+        if frame is None or data is None:
+            return
+        for child in frame.winfo_children():
+            child.destroy()
+        canvas = tk.Canvas(frame)
+        scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
+        scrollable_frame = ttk.Frame(canvas)
+        scrollable_frame.bind(
+            "<Configure>", lambda e, c=canvas: c.configure(scrollregion=c.bbox("all"))
+        )
+        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+        canvas.configure(yscrollcommand=scrollbar.set)
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+        canvas.bind(
+            "<Enter>",
+            lambda e, c=canvas: c.bind_all(
+                "<MouseWheel>", lambda ev: c.yview_scroll(int(-1 * (ev.delta / 120)), "units")
+            ),
+        )
+        canvas.bind("<Leave>", lambda e, c=canvas: c.unbind_all("<MouseWheel>"))
+        canvas.bind("<Button-4>", lambda e, c=canvas: c.yview_scroll(-1, "units"))
+        canvas.bind("<Button-5>", lambda e, c=canvas: c.yview_scroll(1, "units"))
+
+        self.build_nested_frame(scrollable_frame, data, canvas=canvas, path_prefix=key)
+        self.current_tabs[key] = (canvas, scrollable_frame)
+        self.tab_initialized.add(key)
+
+    def on_result_select(self, event: tk.Event) -> None:
+        if not self.search_results:
+            return
+        idx = self.results_listbox.curselection()[0]
+        tab_key, path = self.search_results[idx]
+        tab_index = list(self.current_tabs.keys()).index(tab_key)
+        self.notebook.select(tab_index)
+        canvas, scrollable = self.current_tabs[tab_key]
+        self.scroll_to_path(scrollable, path)
+
+    def scroll_to_path(self, parent: ttk.Frame, path: str) -> None:
+        for widget in parent.winfo_children():
+            result = self.find_widget_by_path(widget, path)
+            if result:
+                widgets_y = result.winfo_rooty() - parent.winfo_rooty()
+                parent_canvas = result.parent_canvas
+                parent_canvas.yview_moveto(widgets_y / parent.winfo_height())
+                result.focus()
+                break
+
+    def find_widget_by_path(self, widget: tk.Widget, path: str):
+        if isinstance(widget, ttk.Entry) and getattr(widget, "full_path", "") == path:
+            return widget
+        if isinstance(widget, (ttk.Frame, ttk.LabelFrame)):
+            for child in widget.winfo_children():
+                found = self.find_widget_by_path(child, path)
+                if found:
+                    return found
+        return None
+
+    # ---------------------------
+    # Diff View
+    # ---------------------------
+    def display_comparison(
+        self,
+        base_data: dict,
+        base_name: str,
+        compare_data: dict,
+        compare_name: str,
+    ) -> None:
+        frame = ttk.Frame(self.notebook)
+        self.notebook.add(frame, text=f"Compare: {compare_name}")
+
+        text_frame = ttk.Frame(frame)
+        text_frame.pack(fill="both", expand=True)
+        text = tk.Text(text_frame, wrap="none")
+        text.pack(fill="both", expand=True, side="left")
+
+        text.bind(
+            "<Enter>",
+            lambda e, t=text: t.bind_all(
+                "<MouseWheel>", lambda ev: t.yview_scroll(int(-1 * (ev.delta / 120)), "units")
+            ),
+        )
+        text.bind("<Leave>", lambda e, t=text: t.unbind_all("<MouseWheel>"))
+        text.bind("<Button-4>", lambda e, t=text: t.yview_scroll(-1, "units"))
+        text.bind("<Button-5>", lambda e, t=text: t.yview_scroll(1, "units"))
+
+        v_scroll = ttk.Scrollbar(text_frame, orient="vertical", command=text.yview)
+        v_scroll.pack(fill="y", side="right")
+        text.configure(yscrollcommand=v_scroll.set)
+
+        h_scroll = ttk.Scrollbar(frame, orient="horizontal", command=text.xview)
+        h_scroll.pack(fill="x", side="bottom")
+        text.configure(xscrollcommand=h_scroll.set)
+
+        try:
+            if diff is None:
+                raise ImportError("jsondiff not available")
+            delta = diff(base_data, compare_data, dump=True)
+            diff_text = json.dumps(delta, indent=2)
+        except Exception:
+            diff_text = "Error generating diff or jsondiff not installed."
+        text.insert("1.0", diff_text)
+
+    # ---------------------------
+    # Heatmap View
+    # ---------------------------
+    def display_heatmap(self) -> None:
+        if len(self.files) <= 1:
+            return
+
+        heat_win = tk.Toplevel(self.root)
+        heat_win.title("Heatmap Comparison")
+        heat_win.geometry("800x600")
+        if hasattr(self, "apply_theme"):
+            self.apply_theme()
+
+        canvas = tk.Canvas(heat_win)
+        canvas.pack(fill="both", expand=True, side="left")
+        v_scroll = ttk.Scrollbar(heat_win, orient="vertical", command=canvas.yview)
+        v_scroll.pack(fill="y", side="right")
+        h_scroll = ttk.Scrollbar(heat_win, orient="horizontal", command=canvas.xview)
+        h_scroll.pack(fill="x", side="bottom")
+        canvas.configure(yscrollcommand=v_scroll.set, xscrollcommand=h_scroll.set)
+
+        heat_frame = ttk.Frame(canvas)
+        canvas.create_window((0, 0), window=heat_frame, anchor="nw")
+        heat_frame.bind(
+            "<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
+
+        keys = sorted({k for f in self.files for k in f["data"].keys()})
+        base_data = self.files[0]["data"]
+
+        matrix: list[list[int]] = []
+        max_score = 0
+        for key in keys:
+            row = []
+            for f in self.files[1:]:
+                score = self.diff_count(base_data.get(key), f["data"].get(key))
+                row.append(score)
+                if score > max_score:
+                    max_score = score
+            matrix.append(row)
+
+        cell = 25
+        for col, f in enumerate(self.files[1:]):
+            ttk.Label(heat_frame, text=f["name"], font=(None, 9, "bold")).grid(
+                row=0, column=col + 1, padx=2, sticky="w"
+            )
+        for row_idx, key in enumerate(keys):
+            ttk.Label(heat_frame, text=key, font=(None, 9, "bold")).grid(
+                row=row_idx + 1, column=0, pady=2, sticky="e"
+            )
+            for col_idx, score in enumerate(matrix[row_idx]):
+                if max_score:
+                    intensity = int(min(score / max_score, 1) * 255)
+                else:
+                    intensity = 0
+                red = 255
+                green_blue = 255 - intensity
+                color = f"#{red:02x}{green_blue:02x}{green_blue:02x}"
+                frame = tk.Frame(
+                    heat_frame, background=color, width=cell, height=cell, borderwidth=1, relief="solid"
+                )
+                frame.grid(row=row_idx + 1, column=col_idx + 1)
+
+    def diff_count(self, a, b) -> int:
+        if a is None and b is None:
+            return 0
+        if isinstance(a, dict) and isinstance(b, dict):
+            keys = set(a.keys()) | set(b.keys())
+            return sum(self.diff_count(a.get(k), b.get(k)) for k in keys)
+        if isinstance(a, list) and isinstance(b, list):
+            length = max(len(a), len(b))
+            return sum(
+                self.diff_count(a[i] if i < len(a) else None, b[i] if i < len(b) else None)
+                for i in range(length)
+            )
+        return 0 if a == b else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - GUI code
+    root = tk.Tk()
+    app = JSONVisualizerApp(root)
+    root.mainloop()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+tk
+jsondiff
+darkdetect

--- a/tooltip.py
+++ b/tooltip.py
@@ -1,0 +1,134 @@
+# Updated tooltips with corrected content
+import tkinter as tk
+
+# ----------------------------
+# TOOLTIP HELPER CLASS
+# ----------------------------
+class Tooltip:
+    """Display a tooltip when hovering over a widget."""
+
+    def __init__(self, widget: tk.Widget, text: str) -> None:
+        self.widget = widget
+        self.text = text
+        self.tipwindow = None
+        widget.bind("<Enter>", self.show)
+        widget.bind("<Leave>", self.hide)
+
+    def show(self, event: tk.Event | None = None) -> None:
+        if self.tipwindow or not self.text:
+            return
+        x = self.widget.winfo_rootx() + 20
+        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 2
+        self.tipwindow = tw = tk.Toplevel(self.widget)
+        tw.wm_overrideredirect(True)
+        tw.wm_geometry(f"+{x}+{y}")
+        label = tk.Label(
+            tw,
+            text=self.text,
+            justify="left",
+            background="#ffffe0",
+            relief="solid",
+            borderwidth=1,
+            font=(None, 9),
+            wraplength=400,
+        )
+        label.pack(ipadx=4, ipady=2)
+
+    def hide(self, event: tk.Event | None = None) -> None:
+        tw = self.tipwindow
+        self.tipwindow = None
+        if tw:
+            tw.destroy()
+
+# ----------------------------
+# SECTION TOOLTIPS DICTIONARY
+# ----------------------------
+SECTION_TOOLTIPS = {
+    "secureme-language": "Localization settings for the Secure.me Web SDK (e.g. text, error messages, language translations).",
+    "shared": "Shared configuration across multiple services (endpoints, timeouts, retention policies).",
+    "secureme": "Secure.me Web SDK—controls session behavior, UI flow, network callbacks, and theming.",
+    "mobilesdk": (
+        "Mobile SDK settings—camera options, retry logic, liveness challenges, and SDC toggles.\n"
+        "\nConfiguration & Flow Layout:\n"
+        "Specify Passive Face Liveness retries, manual capture durations, and whether to record the screen.\n"
+        "\nActive Face Liveness:\n"
+        "Configure AFL options such as PFL max tries, AFL max tries, timeout, and mandatory flags.\n"
+        "\nSmart Document Capture:\n"
+        "Options to detect/display barcode, set SDC timeouts, and enable local/remote SDC.\n"
+        "\nAu10Tix Web App Kit:\n"
+        "Enable SDC front/back, PFL, POA, and adjust kit behaviors for full web integration."
+    ),
+    "bos": "Business Object Service (BOS)—backend verification orchestration, address matching, face comparison thresholds.",
+    "outbox": "Outbox queue configuration—event payload mapping, webhook endpoints, retry/backoff settings.",
+    "instinct": "Instinct fraud detection—historical data lookup, risk indicator thresholds, repetition checks.",
+    "schematest": "Schema test parameters—used to validate JSON structure and run example test cases.",
+    "mobiledemo": "Mobile demo configuration—sample flows for SDC, PFL, and POA with aggregated result display.",
+    "edv": "Electronic Data Vault (EDV)—controls secure data storage, encryption keys, and retrieval policies.",
+    "riskmanager": "Risk Manager settings—defines conflict thresholds, attack magnitude ranges, and logic connections.",
+    "doublecheck": "Secondary review settings—timing rules, notification toggles, and available double-check services.",
+    "bv": "Business Verification—fuzzy matching logic, ID length constraints, and provider-specific flows.",
+    "checksscan": "Check/scan service—parameters for scanning documents and images, including type filters.",
+    "console": "Console UI flags—toggles for upload restrictions, tolerance display, and session recording percentages.",
+    "eds": "Electronic Document Service (EDS)—document handling rules, KYB settings, and provider integration.",
+    "media": "Media processing—image/video token expiry, compression endpoints, and streaming rules.",
+    "phone-email-verification": "OTP settings—PIN length, retry attempts, record lifetimes, and supported channels.",
+    "sdc": (
+        "Serial Fraud Monitor Settings—configure SDC in the General and Advanced Configuration tabs.\n\n"
+        "General Configuration:\n"
+        "• Enable saving hashed document data in SDC to store ID documents and images.\n"
+        "• Enable Query SDC to add SDC analysis in the ID Verification flow (ignores Venture settings).\n"
+        "• Query Data Sources: select Historical, Public Exposed Documents, or Consumer Source Risk Flag.\n"
+        "• Enable Image Quality to allow analysis of poor-quality images.\n"
+        "• Enable Biometrics to save facial identifiers in SDC database.\n"
+        "• Enable Data Sharing Policy to share ID data with consortium organizations and allow querying later.\n"
+        "• Ignore Countries List: add countries to exclude their data from SDC analysis.\n"
+        "• API Result Detail Level: toggle Hide Conflict Info and Hide Repetition to control user-facing details.\n"
+        "Remember to Save & Publish when finished.\n\n"
+        "Advanced Configuration:\n"
+        "(Next page details not provided)"
+    ),
+    "countriesAndIds": (
+        "ID Verification Settings—use the Countries and IDs Settings tab to configure document handling policies per country.\n\n"
+        "• Default Settings: ID Verification Block and Mandatory Both Sides unchecked.\n"
+        "• Document column follows Supported Document List; single-side-only documents disable both-sides option.\n\n"
+        "• Document Versions: modify one version per line, multiple versions via More Actions, or all versions by filtering 'All'.\n\n"
+        "• Other Options: Checking ID Verification Block blocks document types from use; Mandatory Both Sides enforces collection of both sides; if a document lacks a backside, both-sides options are disabled.\n"
+        "Remember to Save & Publish when finished."
+    ),
+    "piiRedaction": (
+        "PII Redaction Settings—configure how Personally Identifiable Information is masked and retained.\n\n"
+        "(Details to be added)"
+    ),
+    "eid": "Electronic ID (eID) settings—supported vendor endpoints, format versions, and autofill behavior.",
+    "webapp": (
+        "AU10TIX Web App Overview:\n"
+        "In the AU10TIX Console, navigate to Settings > Products to access AU10TIX Web App settings. Ensure you are editing the correct organization by checking the organization name under your profile.\n"
+        "The settings page is divided into four tabs: Visual Layout, Flow Layout, General Configuration, and Advanced Configuration.\n\n"
+        "Visual Layout:\n"
+        "• Company: Enter your company name, select or create a Venture, upload a logo and a loading animation (supported formats: GIF, SVG, PNG; recommended size: 430px x 700px).\n"
+        "• Text Customization: Select or upload custom text templates, choose application font (default Montserrat).\n"
+        "• Theme: Toggle light/dark background, set Primary, Success, and Failure colors for buttons and icons. Remember to Save & Publish or Discard Changes.\n"
+        "• Animations: Select light/dark animation theme, upload Lottie JSON files for ID, Selfie, POA, Video Session, Voice Consent, Document Thickness, and ID2 animations.\n\n"
+        "Flow Layout:\n"
+        "• eID Flow: Enable IP-based eID country auto-complete.\n"
+        "• Opening Screen & Wizard: Include or exclude an opening page and wizard steps bar; toggle Acceptable Documents list.\n"
+        "• Platform: Enable PC or Mobile (QR scanning) flows; mobile flow prompts users to switch via QR code.\n"
+        "• Legal Consent: Display a terms consent form (paste text or provide URL in Markdown).\n"
+        "• ID Classification and Collection Policy: Choose Auto ID classification (with optional manual fallback), Manual ID classification (user declaration), or No ID classification. Configure default country and IP-based autofill.\n"
+        "• Flow ID Verification Request Flow: Configure capture options (front/back, POA, Selfie, Voice Consent, Video Session) with Camera/Image upload or Both. Set recording times, language, user agreement toggles, and header for POA.\n"
+        "• Document Thickness: Enable, set front/back/instructions durations, and require user approval if needed.\n\n"
+        "General Configuration:\n"
+        "• Default Invitation Text: Customize invitation message.\n"
+        "• Token Expiration: Set token validity (minutes, hours, days).\n"
+        "• Language: Choose application language, toggle language selector, or enable automatic browser-based language.\n"
+        "• Other Features: Toggle Accessibility panel, Help button, Powered by AU10TIX logo, Front/Back Comparison, Enhanced SDC Feedback, POA Auto Capture, Screen Replay, Kiosk Mode (front-facing camera).\n\n"
+        "Advanced Configuration:\n"
+        "• Redirects: Configure success/failure redirect URLs and mobile callback behaviors (e.g., always use redirects, use after desktop-to-mobile, never use mobile redirects).\n"
+        "• Image Type: Choose how to receive images (URL or Base64).\n"
+        "• Request Headers: Add custom header key:value pairs for session result webhooks.\n"
+        "Remember to Save & Publish or Discard Changes when finished."
+    ),
+    "workflow": "Workflow sequences—defines service order, retry logic, and expiration time for sessions.",
+    "policy": "Policy manager—custom rule definitions, event-based triggers, and active policy toggles.",
+    "biometrics": "Biometrics parameters—face match thresholds, liveness challenge settings, and injection protections.",
+}


### PR DESCRIPTION
## Summary
- move tooltip helper and texts into dedicated `tooltip.py`
- import tooltip definitions from the new module
- document custom tooltip file location in README

## Testing
- `python -m py_compile json_visualizer.py tooltip.py`


------
https://chatgpt.com/codex/tasks/task_e_6840bfbb611c8325b87cf77192ebd9f1